### PR TITLE
Fix parameter `rpc_url` in chain section

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -6,7 +6,7 @@
   "chain": {
     "enabled": true,
     "trail_head_blocks": 5,
-    "rpc_ws": "http://127.0.0.1:8545",
+    "rpc_url": "http://127.0.0.1:8545",
     "coordinator_address": "0x...",
     "wallet": {
       "max_gas_limit": 5000000,


### PR DESCRIPTION
Actually, our python script named `activate_node` is trying to run our rpc using the parameter named `rpc_url` loaded from config file.

`/scripts/activate_node.py`
```
#Load config
config: ConfigDict = load_validated_config()

#Create new RPC, Wallet
rpc = RPC(config["chain"]["rpc_url"])
```

This PR contains a change to fix the parameter name in `config_sample.json` file to use the correct name.