### PR TITLE
Add volume support to docker config

### DIFF
--- a/src/orchestration/docker.py
+++ b/src/orchestration/docker.py
@@ -387,5 +387,6 @@ class ContainerManager(AsyncTask):
                         "MaximumRetryCount": 5,
                     },
                     device_requests=device_requests,
+                    volumes=config.get("volumes", []),
                 )
                 log.info(f"Created and started new container: {id}")


### PR DESCRIPTION
Currently if we want to allow `manage_containers` we don't pass down volume mounts to the node. This will allow users to set `manage_containers` to `True` and still have the ability to define a volume mount in the `config.json`.

Volume mounts are handy for huggingface models cache, so at container start we don't need to re-pull the files, like so:

```json
        "volumes": [
          "/home/ubuntu/.cache:/root/.cache:rw"
        ],
```

Not sure if this was intentionally left out